### PR TITLE
WIP: safe-string support

### DIFF
--- a/bin/maildir.ml
+++ b/bin/maildir.ml
@@ -1,3 +1,4 @@
+module Practicality = String
 open Astring
 open MrMime
 
@@ -74,7 +75,7 @@ let read_into ?(newline = LF) channel buf off len =
       if remaining = 0 then len
       else match input_char channel with
            | '\n' when not has_cr && remaining >= 2 ->
-             Bytes.blit "\r\n" 0 buf (last - remaining) 2;
+             Bytes.blit (Bytes.of_string "\r\n") 0 buf (last - remaining) 2;
              read_char false (remaining - 2)
            | '\n' when not has_cr && remaining = 1 ->
              let pos = pos_in channel in
@@ -166,7 +167,7 @@ let path =
 
 let newline =
   let parse s =
-    match Bytes.uppercase_ascii s with
+    match Practicality.uppercase_ascii s with
     | "CRLF" -> `Ok CRLF
     | "LF" -> `Ok LF
     | _ -> `Error "Invalid newline."

--- a/lib/encoder.ml
+++ b/lib/encoder.ml
@@ -24,7 +24,7 @@ let flush p state =
 let wait k state = `Wait k
 
 let rec writes s k state =
-  let len = String.length state.buffer in
+  let len = Bytes.length state.buffer in
   let rec loop j l state =
     let rem = len - state.pos in
     let len = if l > rem then rem else l in

--- a/lib/internal_buffer.ml
+++ b/lib/internal_buffer.ml
@@ -29,7 +29,7 @@ struct
     let r = Bytes.create len in
     let s = sub t off len in
     Bytes.iteri (fun i _ -> Bytes.set r i (get s i)) r;
-    Bytes.unsafe_to_string r
+    r
 
   let blit src src_idx dst dst_idx len =
     let src = Array1.sub src src_idx len in
@@ -120,7 +120,7 @@ let sub (type a) (v : a t) off len : a t = match v with
   | Bigstring v -> from_bigstring @@ Bigstring.sub v off len
 
 let sub_string (type a) (v : a t) off len = match v with
-  | Bytes v -> Bytes.sub_string v off len
+  | Bytes v -> Bytes.sub v off len
   | Bigstring v -> Bigstring.sub_string v off len
 
 let to_string (type a) (v : a t) = match v with

--- a/lib/mrMime.mli
+++ b/lib/mrMime.mli
@@ -28,6 +28,6 @@ sig
   val decoder_src      : ('input, 'a) decoder -> 'input Input.t
   val decoder          : 'input Input.t -> 'a Parser.t -> ('input, 'a) decoder
   val decode           : ('input, 'a) decoder -> 'a decoding
-  val src              : ('input, 'a) decoder -> string -> int -> int -> unit
+  val src              : ('input, 'a) decoder -> bytes -> int -> int -> unit
   val decoding         : ('input, 'a) decoder -> 'b Parser.t -> ('input, 'b) decoder
 end

--- a/lib/mrMime_address.ml
+++ b/lib/mrMime_address.ml
@@ -481,6 +481,6 @@ struct
   let add_literal_domain tag literal_domain =
     if String.length tag >= 1
        && ldh_str tag
-    then Hashtbl.add Rfc5321.iana_hashtbl tag literal_domain
+    then Hashtbl.add Rfc5321.iana_hashtbl (Bytes.of_string tag) literal_domain
     else raise (Invalid_argument "Address.Extension.add_literal_domain: bad tag")
 end

--- a/lib/mrMime_base64.ml
+++ b/lib/mrMime_base64.ml
@@ -194,7 +194,7 @@ struct
     let add chr k ({ state; buffer; seek; _ } as t) =
       if seek >= 2
       then begin
-        let a, b, c = buffer.[0], buffer.[1], chr in
+        let a, b, c = Bytes.get buffer 0, Bytes.get buffer 1, chr in
         (if t.wrap
          then wrap
          else noop)
@@ -229,7 +229,7 @@ struct
       (fun ({ state; buffer; seek; _ } as t) ->
        match seek with
        | 2 ->
-         let b, c = buffer.[0], buffer.[1] in
+         let b, c = Bytes.get buffer 0, Bytes.get buffer 1 in
 
          t.seek <- 0;
 
@@ -249,7 +249,7 @@ struct
          (fun state -> k { t with state = state; seek = 0 })
          state
        | 1 ->
-         let c = buffer.[0] in
+         let c = Bytes.get buffer 0 in
 
          t.seek <- 0;
 

--- a/lib/mrMime_base64.mli
+++ b/lib/mrMime_base64.mli
@@ -99,4 +99,4 @@ val decode        : 'a decoder -> decoding
     until [`Continue] is returned.  To signal the end of input call the function
     with [len = 0].
 *)
-val src           : 'a decoder -> string -> int -> int -> unit
+val src           : 'a decoder -> bytes -> int -> int -> unit

--- a/lib/mrMime_message.ml
+++ b/lib/mrMime_message.ml
@@ -79,7 +79,7 @@ struct
        >>= fun field_name -> Rfc5322.field (Rfc2045.message_field
                                             (fun _ -> fail Rfc5322.Nothing_to_do)
                                             (fun _ -> fail Rfc5322.Nothing_to_do))
-                                           field_name)
+                                           (Bytes.to_string field_name))
     in
     rule >>= fun field -> match skipped, field with
       | None, #Rfc5322.skip -> return `Skip
@@ -175,7 +175,7 @@ struct
           >>| fun v -> Top.Base64 v
         | _ ->
           Rfc5322.decode boundary' rollback
-          >>| fun v -> Top.Raw v
+          >>| fun v -> Top.Raw (Bytes.to_string v)
       in
 
       option None (Rfc822.crlf *> decoder >>| fun v -> Some v)

--- a/lib/mrMime_parser.mli
+++ b/lib/mrMime_parser.mli
@@ -137,7 +137,7 @@ val satisfy      : (char -> bool) -> char t
     input and [s] with [f s = f s'] (in another case, the parser fails with
     {!String}). The parser advances the input of [String.length s] byte(s).
 *)
-val string       : (string -> string) -> string -> string t
+val string       : (string -> string) -> string -> bytes t
 
 (** [store buf  f] stores any  character for which  [f] returns [true]  in [buf]
     only on the continuous buffer  inside the input.  That means,  [store buf f]
@@ -178,7 +178,7 @@ val option       : 'a -> 'a t -> 'a t
 (** [take n] accepts exactly [n] character(s) of input and returns them as a
     string.
 *)
-val take         : int -> string t
+val take         : int -> bytes t
 
 (** [list ps] runs each [p] in [ps] in sequence, returning a list of results of
     each [p].

--- a/lib/mrMime_quotedPrintable.ml
+++ b/lib/mrMime_quotedPrintable.ml
@@ -102,7 +102,7 @@ struct
            let n = Input.transmit i @@ fun buff off len ->
 
              let len' = locate buff off len is_ in
-             Buffer.add_string buffer (Internal_buffer.sub_string buff off len');
+             Buffer.add_bytes buffer (Internal_buffer.sub_string buff off len');
              len'
            in
 
@@ -377,7 +377,7 @@ let p boundary t =
          let n = Input.transmit i @@ fun buff off len ->
 
            let len' = locate buff off len is_ in
-           Buffer.add_string t.buffer (Internal_buffer.sub_string buff off len');
+           Buffer.add_bytes t.buffer (Internal_buffer.sub_string buff off len');
            len'
          in
 

--- a/lib/mrMime_quotedPrintable.mli
+++ b/lib/mrMime_quotedPrintable.mli
@@ -102,4 +102,4 @@ val decode        : 'a decoder -> decoding
     until [`Continue] is returned.  To signal the end of input call the function
     with [len = 0].
 *)
-val src           : 'a decoder -> string -> int -> int -> unit
+val src           : 'a decoder -> bytes -> int -> int -> unit

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -182,7 +182,7 @@ sig
   val prompt  : 'input Input.t -> ('input Input.t -> s -> ('a, 'input) state) -> ('input Input.t -> s -> ('a, 'input) state) -> ('a, 'input) state
   val expect  : unit t
   val require : int -> 'input Input.t -> s -> ('a, 'input) fail -> (unit, 'a, 'input) success -> ('a, 'input) state
-  val ensure  : int -> string t
+  val ensure  : int -> bytes t
 end
 
 module type C =
@@ -196,14 +196,14 @@ sig
   val advance      : int -> unit t
   val satisfy      : (char -> bool) -> char t
   val print        : string -> unit t
-  val string       : (string -> string) -> string -> string t
+  val string       : (string -> string) -> string -> bytes t
   val store        : Buffer.t -> (char -> bool) -> int t
   val recognize    : (char -> bool) -> string t
   val char         : char -> char t
   val many         : 'a t -> 'a list t
   val one          : 'a t -> 'a list t
   val option       : 'a -> 'a t -> 'a t
-  val take         : int -> string t
+  val take         : int -> bytes t
   val list         : 'a t list -> 'a list t
   val count        : int -> 'a t -> 'a list t
   val repeat'      : Buffer.t -> int option -> int option -> (char -> bool) -> int t
@@ -305,7 +305,7 @@ struct
   let string f s =
     let len = String.length s in
     IO.ensure len >>= fun s' ->
-      if f s = f s'
+      if f s = f (Bytes.to_string s')
       then advance len *> return s'
       else fail String
 
@@ -313,7 +313,7 @@ struct
     { f = fun i s fail succ ->
       let recognize buff off len =
         let len' = locate buff off len f in
-        Buffer.add_string buffer (Internal_buffer.sub_string buff off len');
+        Buffer.add_bytes buffer (Internal_buffer.sub_string buff off len');
         len'
       in
 
@@ -391,7 +391,7 @@ struct
                b - (Buffer.length buffer)
              | _ -> len'
            in
-           Buffer.add_string buffer (Internal_buffer.sub_string buff off len');
+           Buffer.add_bytes buffer (Internal_buffer.sub_string buff off len');
            len') in
 
         succ i s consumed } *> m

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -51,7 +51,7 @@ sig
   val prompt  : 'input Input.t -> ('input Input.t -> s -> ('a, 'input) state) -> ('input Input.t -> s -> ('a, 'input) state) -> ('a, 'input) state
   val expect  : unit t
   val require : int -> 'input Input.t -> s -> ('a, 'input) fail -> (unit, 'a, 'input) success -> ('a, 'input) state
-  val ensure  : int -> string t
+  val ensure  : int -> bytes t
 end
 
 module type C =
@@ -65,14 +65,14 @@ sig
   val advance      : int -> unit t
   val satisfy      : (char -> bool) -> char t
   val print        : string -> unit t
-  val string       : (string -> string) -> string -> string t
+  val string       : (string -> string) -> string -> bytes t
   val store        : Buffer.t -> (char -> bool) -> int t
   val recognize    : (char -> bool) -> string t
   val char         : char -> char t
   val many         : 'a t -> 'a list t
   val one          : 'a t -> 'a list t
   val option       : 'a -> 'a t -> 'a t
-  val take         : int -> string t
+  val take         : int -> bytes t
   val list         : 'a t list -> 'a list t
   val count        : int -> 'a t -> 'a list t
   val repeat'      : Buffer.t -> int option -> int option -> (char -> bool) -> int t

--- a/lib/rfc2045.ml
+++ b/lib/rfc2045.ml
@@ -230,14 +230,14 @@ let entity_part_headers extend_mime extend =
   many ((Rfc5322.field_name
          <* (many (satisfy (function '\x09' | '\x20' -> true | _ -> false)))
          <* char ':'
-         >>= fun field_name -> part_field extend_mime extend field_name)
+         >>= fun field_name -> part_field extend_mime extend (Bytes.to_string field_name))
         <|> (Rfc5322.skip >>| fun v -> `Skip v))
 
 let entity_message_headers extend_mime extend =
   many (Rfc5322.field_name
         <* (many (satisfy (function '\x09' | '\x20' -> true | _ -> false)))
         <* char ':'
-        >>= fun field_name -> message_field extend_mime extend field_name)
+        >>= fun field_name -> message_field extend_mime extend (Bytes.to_string field_name))
 
 let mime_message_headers extend_mime extend =
   entity_message_headers

--- a/lib/rfc5321.mli
+++ b/lib/rfc5321.mli
@@ -15,8 +15,8 @@ val ipv4_address_literal    : Ipaddr.V4.t t
 val ipv6_addr               : Ipaddr.V6.t t
 val ipv6_address_literal    : Ipaddr.V6.t t
 val let_dig                 : char t
-val ldh_str                 : string t
+val ldh_str                 : bytes t
 val general_address_literal : literal_domain t
 val address_literal         : literal_domain t
 
-val iana_hashtbl            : (string, literal_domain t) Hashtbl.t
+val iana_hashtbl            : (bytes, literal_domain t) Hashtbl.t

--- a/lib/rfc5322.mli
+++ b/lib/rfc5322.mli
@@ -127,10 +127,10 @@ val unstructured     : unstructured t
 val phrase_or_msg_id : phrase_or_msg_id list t
 val obs_phrase_list  : phrase list t
 val keywords         : phrase list t
-val field_name       : string t
+val field_name       : bytes t
 
 val field            : (string -> ([> field ] as 'a) t) -> string -> 'a t
 val skip             : string t
 val header           : (string -> ([> skip | field ] as 'a) t) -> 'a list t
 
-val decode           : unit t -> unit t -> string t
+val decode           : unit t -> unit t -> bytes t

--- a/lib/rfc6532.ml
+++ b/lib/rfc6532.ml
@@ -42,7 +42,7 @@ let str f =
                   else fail i s [] Empty_string)
                  (loop consumed)
       | `Await when Input.ravailable i = 0 && s = Complete ->
-        Uutf.Manual.src decoder "" 0 0;
+        Uutf.Manual.src decoder Bytes.empty 0 0;
         loop consumed i s
 
         (*

--- a/lib/top.ml
+++ b/lib/top.ml
@@ -73,10 +73,10 @@ let octet boundary content fields =
     >>| fun v -> Base64 v
   | `Bit7 | `Bit8 | `Binary ->
     Rfc5322.decode boundary rollback
-    >>| fun v -> Raw v
+    >>| fun v -> Raw (Bytes.to_string v)
   | `Ietf_token s | `X_token s ->
     try (Hashtbl.find decoder_hashtbl s) boundary rollback
-    with Not_found -> Rfc5322.decode boundary rollback >>| fun v -> Raw v
+    with Not_found -> Rfc5322.decode boundary rollback >>| fun v -> Raw (Bytes.to_string v)
 
 let discard = function
   | None ->


### PR DESCRIPTION
This is a highly hacked set of changes to enable building with safe-string on OCaml 4.06+

I say highly hacked because the only thing it has going for it is that the testsuite passes!

I have for the most part done this by changing `string` to `bytes` with no consideration for whether that's the right API - the .mli changes are in a separate commit to allow those to be reviewed first.
