### PR TITLE
dune no longer recognises the --dev flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DUNE=dune
 
 all:
-	$(DUNE) build --dev @install @DEFAULT
+	$(DUNE) build @install @DEFAULT
 
 install:
 	$(DUNE) install


### PR DESCRIPTION
This fixes the default Makefile with dune.1.1.1